### PR TITLE
refactor: allow CouchbaseSession to be provided externally

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -25,15 +25,9 @@ type Auth struct {
 func New(config *Config) *Auth {
 	auth := &Auth{
 		JwtSecretKey:        []byte(config.JwtSecretKey),
+		Couchbase:           config.Couchbase,
 		EndPointPermissions: config.EndpointPermissions,
 	}
-
-	couchbaseStore, err := GetCouchbaseStore(config.Couchbase)
-	if err != nil {
-		panic(err)
-	}
-	auth.Couchbase = couchbaseStore
-
 	return auth
 }
 

--- a/config.go
+++ b/config.go
@@ -8,7 +8,7 @@ const AllUser = 999
 type Config struct {
 	Header              HeaderConfig
 	Payload             PayloadConfig
-	Couchbase           CouchbaseConfig
+	Couchbase           *CouchbaseStore
 	JwtSecretKey        string
 	EndpointPermissions map[string]int
 }

--- a/couchbase.go
+++ b/couchbase.go
@@ -1,9 +1,7 @@
 package auth
 
 import (
-	"fmt"
 	"github.com/couchbase/gocb/v2"
-	"sync"
 	"time"
 )
 
@@ -21,44 +19,4 @@ type CouchbaseStore struct {
 	Cluster    *gocb.Cluster
 	Bucket     *gocb.Bucket
 	Collection *gocb.Collection
-}
-
-var (
-	storeInstance *CouchbaseStore
-	once          sync.Once
-)
-
-func GetCouchbaseStore(config CouchbaseConfig) (*CouchbaseStore, error) {
-	var err error
-	once.Do(func() {
-		cluster, e := gocb.Connect(config.ConnStr, gocb.ClusterOptions{
-			Username: config.Username,
-			Password: config.Password,
-		})
-		if e != nil {
-			err = e
-			return
-		}
-		err = cluster.WaitUntilReady(config.Timeout, nil)
-		if err != nil {
-			panic(fmt.Sprintf("Cluster is not ready or credentials invalid: %v", err))
-		}
-
-		bucket := cluster.Bucket(config.BucketName)
-		if e = bucket.WaitUntilReady(config.Timeout, nil); e != nil {
-			err = e
-			return
-		}
-
-		scope := bucket.Scope(config.Scope)
-		collection := scope.Collection(config.Collection)
-
-		storeInstance = &CouchbaseStore{
-			Cluster:    cluster,
-			Bucket:     bucket,
-			Collection: collection,
-		}
-	})
-
-	return storeInstance, err
 }


### PR DESCRIPTION
Previously, CouchbaseStore was created within the New method using a separate configuration function. Now, CouchbaseStore is directly injected via the Config struct, allowing for external configuration of the Couchbase connection and store instance.